### PR TITLE
Do not add locked outputs to AvailableCoins

### DIFF
--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -138,7 +138,7 @@ UniValue masternode(const UniValue& params, bool fHelp)
                 "  current      - Print info on current masternode winner to be paid the next block (calculated locally)\n"
                 "  genkey       - Generate new masternodeprivkey\n"
 #ifdef ENABLE_WALLET
-                "  outputs      - Print masternode compatible outputs\n"
+                "  outputs      - Print masternode compatible (unlocked) outputs\n"
                 "  start-alias  - Start single remote masternode by assigned alias configured in masternode.conf\n"
                 "  start-<mode> - Start remote masternodes configured in masternode.conf (<mode>: 'all', 'missing', 'disabled')\n"
 #endif // ENABLE_WALLET

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2395,7 +2395,10 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
                     found = true;
                 }
                 if(!found) continue;
-
+                // Do not add locked coins
+		        if(IsLockedCoin((*it).first, i))
+			        continue;
+                
                 isminetype mine = IsMine(pcoin->vout[i]);
                 if (!(IsSpent(wtxid, i)) && mine != ISMINE_NO &&
                     (!IsLockedCoin((*it).first, i) || nCoinType == ONLY_1000) &&


### PR DESCRIPTION
This solves the issue with masternode outputs displaying both used (locked) and unused outputs at the same time, which becomes a bigger issue the more nodes you have.