### PR TITLE
[qt] Fix LastSeen for Missing MNs

### DIFF
--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -203,8 +203,7 @@ void MasternodeList::updateMyMasternodeInfo(QString strAlias, QString strAddr, c
     QTableWidgetItem *protocolItem = new QTableWidgetItem(QString::number(fFound ? infoMn.nProtocolVersion : -1));
     QTableWidgetItem *statusItem = new QTableWidgetItem(QString::fromStdString(fFound ? CMasternode::StateToString(infoMn.nActiveState) : "MISSING"));
     QTableWidgetItem *activeSecondsItem = new QTableWidgetItem(QString::fromStdString(DurationToDHMS(fFound ? (infoMn.nTimeLastPing - infoMn.sigTime) : 0)));
-    QTableWidgetItem *lastSeenItem = new QTableWidgetItem(QString::fromStdString(DateTimeStrFormat("%Y-%m-%d %H:%M",
-                                                                                                   fFound ? infoMn.nTimeLastPing + GetOffsetFromUtc() : 0)));
+    QTableWidgetItem *lastSeenItem = new QTableWidgetItem(QString::fromStdString(fFound ? DateTimeStrFormat("%Y-%m-%d %H:%M", infoMn.nTimeLastPing + GetOffsetFromUtc()) : ""));
     QTableWidgetItem *pubkeyItem = new QTableWidgetItem(QString::fromStdString(fFound ? CBitcoinAddress(infoMn.pubKeyCollateralAddress.GetID()).ToString() : ""));
 
     ui->tableWidgetMyMasternodes->setItem(nNewRow, 0, aliasItem);


### PR DESCRIPTION
It will no longer display the year 1970 as 'LastSeen' for MISSING nodes. Before change:
![51-15](https://user-images.githubusercontent.com/17365556/41285306-0586b1ec-6e3c-11e8-95d6-7a5644f9a574.png)

After change:
![58-17](https://user-images.githubusercontent.com/17365556/41285305-056b0b5e-6e3c-11e8-8b24-a56186ad4a96.png)